### PR TITLE
Changed ncores to a user-defined parameter in ptGetTop()

### DIFF
--- a/R/tsp_rf.R
+++ b/R/tsp_rf.R
@@ -1,5 +1,6 @@
 # for TSP-RF
 # (C) 2018 Patrick Cahan
+# EDITED BY SK - changed memory usage in ptGetTop
 
 
 
@@ -131,12 +132,12 @@ ptGetTop<-function
 (expDat,
  cell_labels,
  topX=50,
- sliceSize = 5e3){
+ sliceSize = 5e3,
+ ncores = detectCores()){
 
 	ans<-vector()
 	genes<-rownames(expDat)
-
-	ncores <- detectCores()
+	
 	mcCores <- 1
 	if(ncores>1){
 		mcCores <- ncores - 1

--- a/R/tsp_rf.R
+++ b/R/tsp_rf.R
@@ -1,6 +1,5 @@
 # for TSP-RF
 # (C) 2018 Patrick Cahan
-# EDITED BY SK - changed memory usage in ptGetTop
 
 
 
@@ -134,7 +133,7 @@ ptGetTop<-function
  topX=50,
  sliceSize = 5e3,
  ncores = detectCores()){
-
+#Change by SK to allow ncores as a user-selected parameter (default to original value, which was number of detected cores)
 	ans<-vector()
 	genes<-rownames(expDat)
 	


### PR DESCRIPTION
Changes ncores to allow for user input in ptGetTop(), with the default value set to the previously defined value (detectCores()).